### PR TITLE
Create .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+# Build all branches, *including* gh-pages:
+branches:
+  only:
+  - gh-pages
+  - /.*/


### PR DESCRIPTION
close #2 

> If you use both a safelist and a blocklist, the safelist takes precedence. By default, the gh-pages branch is not built unless you add it to the safelist.
> 
> To build all branches:
> 
> ```
> branches:
>   only:
>   - gh-pages
>   - /.*/
> ```

reference: https://docs.travis-ci.com/user/customizing-the-build/#Safelisting-or-blocklisting-branches