### PR TITLE
[WIP] 更新 .travis.yml : update submodule before deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,28 @@ branches:
   only:
   - gh-pages
   - /.*/
+
+# Disable default behavior: `git submodule update --init --recursive`
+git:
+  submodules: false
+
+# Skip install steps cuz nothing to install
+install: true
+
+# Overwrite defulat test commands
+script:
+  - echo "No test to run. Nothing to build. Just run to update submodule"
+
+# Update submodules
+before_deploy:
+  - git submodule update --init 2018
+  - # add more scripts here. eg: `git update sumodule 2016`
+
+# Deploy to gh-pages branch (https://docs.travis-ci.com/user/deployment/pages/)
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
+  keep-history: true
+  on:
+    branch: gh-pages


### PR DESCRIPTION
目前 before_deploy 能正常 update submodule，但 deploy 不會 commit `.gitmodules` 的更新

build logs: https://travis-ci.org/g0v/summit.g0v.tw/builds/356969000


```
### before_deploy
$ git submodule update --init 2018
Submodule '2018' (https://github.com/g0v/summit2018.git) registered for path '2018'
Cloning into '/home/travis/build/g0v/summit.g0v.tw/2018'...
Submodule path '2018': checked out '84b607413db0f428febe9f1782c1ef9576cdda45'

...

### Deploying application
cd /tmp/d20180322-3542-1d8tqma/work
On branch gh-pages
Your branch is up to date with 'origin/gh-pages'.
nothing to commit, working tree clean
commit dac3d401f32dad5517e6d489dadf60cfaf184a0d
Author: Lawrence Chou <choznerol@gmail.com>
Date:   Thu Mar 22 22:46:57 2018 +0800
    Merge pull request #3 from g0v/intergate-travis-ci
    
    Create .travis.yml
 .gitmodules | 12 ++++++++++++
 .travis.yml |  5 +++++
 2014        |  1 +
 2016        |  1 +
 2018        |  1 +
 404.html    | 48 ++++++++++++++++++++++++++++++++++++++++++++++++
 CNAME       |  1 +
 index.html  | 12 ++++++++++++
 8 files changed, 81 insertions(+)
cd -
Done. Your build exited with 0.
```